### PR TITLE
Always log stack trace when pickle code throws exception

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -60,8 +60,7 @@ def exit_with_help(error):
     logging.root.handlers[0].setFormatter(logging.Formatter("%(message)s"))
 
     logging.info("-"*80)
-    logging.info("Having problems?")
-    logging.info("\nDebug your pickle model locally via docker command:")
+    logging.info("Debug your pickle model locally via docker command:")
     logging.info(f'\n docker run -i --rm -v "$PWD:$PWD" {docker_image_path} {docker_args}')
     logging.info("\nTry our other support resources:")
     logging.info(" [Github]  https://github.com/numerai/numerai-predict")


### PR DESCRIPTION
Add help message with docker command and links to support
```
INFO:root:Python 3.10.12 (main, Jun  7 2023, 19:37:06) [GCC 10.2.1 20210110]
INFO:root:Loading model /Users/pschork/workspace/numerai-predict/assert.pkl
INFO:root:Using NumerAPI to download v4.1/live.parquet for live data
INFO:numerapi.utils:starting download
/tmp/v4.1/live.parquet: 4.45MB [00:00, 12.2MB/s]
INFO:root:Loading live features /tmp/v4.1/live.parquet
INFO:root:Predicting on 4911 rows of live features
ERROR:root:This is bad code
Traceback (most recent call last):
  File "//predict.py", line 129, in main
    predictions = model(live_features)
  File "/Users/pschork/workspace/hello-numerai-models/assert.py", line 4, in predict
AssertionError: This is bad code
--------------------------------------------------------------------------------
Debug your pickle model locally via docker command:

 docker run -i --rm -v "$PWD:$PWD" ghcr.io/numerai/numerai_predict_py_3_10:latest --debug --model $PWD/[PICKLE_FILE]

Try our other support resources:
 [Github]  https://github.com/numerai/numerai-predict
 [Discord] https://discord.com/channels/894652647515226152/1089652477957246996
--------------------------------------------------------------------------------
```