### PR TITLE
Bump GitHub Actions workflow versions

### DIFF
--- a/.github/workflows/deploy-images.yml
+++ b/.github/workflows/deploy-images.yml
@@ -23,7 +23,7 @@ jobs:
       packages: write
       contents: read
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Extract short git SHA
         run: echo "GIT_REF=`git rev-parse --short HEAD`" >> $GITHUB_ENV
@@ -36,10 +36,10 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
@@ -75,19 +75,19 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::${{ env.MODEL_UPLOADS_ECR_ACCOUNT_ID }}:role/github-actions
           aws-region: us-west-2
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and Push Docker Image
         run: ACCOUNT_ID=${{ env.MODEL_UPLOADS_ECR_ACCOUNT_ID }} make push_latest_${{ format(matrix.python-version, '_') }}

--- a/.github/workflows/deploy-shell.yaml
+++ b/.github/workflows/deploy-shell.yaml
@@ -20,7 +20,7 @@ jobs:
       packages: write
       contents: read
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Extract short git SHA
         run: echo "GIT_REF=`git rev-parse --short HEAD`" >> $GITHUB_ENV
@@ -39,10 +39,10 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}_shell
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Push Docker image as LATEST to Github Container registry
         uses: docker/build-push-action@v6
@@ -68,10 +68,10 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::${{ env.MODEL_UPLOADS_ECR_ACCOUNT_ID }}:role/github-actions
           aws-region: us-west-2

--- a/.github/workflows/deploy-stable.yaml
+++ b/.github/workflows/deploy-stable.yaml
@@ -20,7 +20,7 @@ jobs:
       packages: write
       contents: read
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Log in to Github Container registry
         uses: docker/login-action@v3
@@ -36,10 +36,10 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}_py_${{ format(matrix.python-version, '_') }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Push Docker image to Github Container registry
         uses: docker/build-push-action@v6
@@ -59,10 +59,10 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::${{ secrets.MODEL_UPLOADS_ACCOUNT_ID }}:role/github-actions
           aws-region: us-west-2

--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -8,13 +8,13 @@ jobs:
   test-predict:
     runs-on: ubuntu-latest-4core
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Test predict.py
         run: make test_predict
@@ -25,13 +25,13 @@ jobs:
         python-version: ['3_10', '3_11', '3_12', '3_13']
     runs-on: ubuntu-latest-4core
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Test Python ${{ matrix.python-version }}
         run: make test_${{ matrix.python-version }}


### PR DESCRIPTION
## Summary
- bump GitHub Actions workflow versions across deploy and test workflows
- move checkout and AWS credential actions to current major versions
- move docker setup actions to current major versions to address the Node 20 deprecation warning

## Validation
- parsed all workflow YAML files locally with Ruby YAML
- confirmed the old action tags are no longer present