### PR TITLE
Default predict.py data and benchmark params to v5.3

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -21,12 +21,12 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--dataset",
-        default="v5.2/live.parquet",
+        default="v5.3/live.parquet",
         help="Numerapi dataset path or local file.",
     )
     parser.add_argument(
         "--benchmarks",
-        default="v5.2/live_benchmark_models.parquet",
+        default="v5.3/live_benchmark_models.parquet",
         help="Numerapi benchmark model path or local file.",
     )
     parser.add_argument("--model", required=True, help="Pickled model file or URL")

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -80,8 +80,8 @@ class TestPredict(unittest.TestCase):
 
     def test__main_exits_with_help_on_python_version_pickle_mismatch(self):
         args = argparse.Namespace(
-            dataset="v5.2/live.parquet",
-            benchmarks="v5.2/live_benchmark_models.parquet",
+            dataset="v5.3/live.parquet",
+            benchmarks="v5.3/live_benchmark_models.parquet",
             model="model.pkl",
             output_dir="/tmp",
             post_url=None,


### PR DESCRIPTION
Updates `predict.py` default `--dataset` and `--benchmarks` args to use the v5.3 data.